### PR TITLE
Reload only latest active tabs feature

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -19,37 +19,43 @@ const MainLayer = Layer.mergeAll(
   MeasurementServiceLive
 )
 
+// Constants for keepalive configuration
+const KEEPALIVE_ALARM_NAME = 'keepalive' as const
+const KEEPALIVE_INTERVAL_MINUTES = 0.5 as const
+
+// Constants for tab reload configuration
+const TAB_URL_PATTERNS = ['http://*/*', 'https://*/*'] as const
+const HEALTH_CHECK_TIMEOUT_MS = 100 as const
+const HEALTH_CHECK_MESSAGE_TYPE = 'ping' as const
+
+// Priority weights for smart reloading
+const PRIORITY_WEIGHTS = {
+  ACTIVE_TAB: 1000,
+  RECENT_ONE_HOUR: 500,
+  RECENT_ONE_DAY: 100,
+  LOADED_TAB: 50, // Tab loaded in memory (not discarded)
+  PINNED_TAB: 25,
+} as const
+
+// Time thresholds in hours
+const TIME_THRESHOLDS = {
+  ONE_HOUR: 1,
+  ONE_DAY: 24,
+} as const
+
+const MILLISECONDS_PER_HOUR = 1000 * 60 * 60 as const
+
 const setupKeepalive = (): Effect.Effect<void, never, never> =>
   Effect.sync(() => {
-    chrome.alarms.create('keepalive', { periodInMinutes: 0.5 })
+    chrome.alarms.create(KEEPALIVE_ALARM_NAME, { periodInMinutes: KEEPALIVE_INTERVAL_MINUTES })
     chrome.alarms.onAlarm.addListener((alarm) => {
-      if (alarm.name === 'keepalive') {
+      if (alarm.name === KEEPALIVE_ALARM_NAME) {
         // Keepalive triggered
       }
     })
   })
 
 let postInstallReloadRegistered = false
-
-// Check if content script is already loaded in a tab
-const checkContentScriptLoaded = (tabId: number): Promise<boolean> =>
-  new Promise((resolve) => {
-    try {
-      chrome.tabs.sendMessage(tabId, { type: 'ping' }, (response) => {
-        // If we get a response and no error, content script is loaded
-        if (chrome.runtime.lastError || !response || !response.loaded) {
-          resolve(false)
-        } else {
-          resolve(true)
-        }
-      })
-    } catch {
-      resolve(false)
-    }
-
-    // Timeout after 100ms - if no response, assume not loaded
-    setTimeout(() => resolve(false), 100)
-  })
 
 // Tab priority for smart reloading
 interface TabWithPriority {
@@ -58,75 +64,137 @@ interface TabWithPriority {
   needsReload: boolean
 }
 
+// Check if content script is already loaded in a tab
+const checkContentScriptLoaded = (tabId: number): Effect.Effect<boolean, never, never> =>
+  Effect.async<boolean, never, never>((resume) => {
+    let responded = false
+
+    const respond = (value: boolean) => {
+      if (!responded) {
+        responded = true
+        resume(Effect.succeed(value))
+      }
+    }
+
+    try {
+      chrome.tabs.sendMessage(tabId, { type: HEALTH_CHECK_MESSAGE_TYPE }, (response) => {
+        if (chrome.runtime.lastError || !response || !response.loaded) {
+          respond(false)
+        } else {
+          respond(true)
+        }
+      })
+    } catch {
+      respond(false)
+    }
+
+    // Timeout if no response
+    setTimeout(() => respond(false), HEALTH_CHECK_TIMEOUT_MS)
+  })
+
 // Determine reload priority: higher = more important
 const getTabPriority = (tab: chrome.tabs.Tab): number => {
   let priority = 0
 
   // Highest priority: active tab in current window
-  if (tab.active) priority += 1000
+  if (tab.active) {
+    priority += PRIORITY_WEIGHTS.ACTIVE_TAB
+  }
 
-  // High priority: recently accessed tabs (based on tab.lastAccessed if available)
+  // High priority: recently accessed tabs
   if (tab.lastAccessed) {
-    const hoursSinceAccess = (Date.now() - tab.lastAccessed) / (1000 * 60 * 60)
-    if (hoursSinceAccess < 1) priority += 500      // Last hour
-    else if (hoursSinceAccess < 24) priority += 100 // Last 24 hours
+    const hoursSinceAccess = (Date.now() - tab.lastAccessed) / MILLISECONDS_PER_HOUR
+    if (hoursSinceAccess < TIME_THRESHOLDS.ONE_HOUR) {
+      priority += PRIORITY_WEIGHTS.RECENT_ONE_HOUR
+    } else if (hoursSinceAccess < TIME_THRESHOLDS.ONE_DAY) {
+      priority += PRIORITY_WEIGHTS.RECENT_ONE_DAY
+    }
   }
 
   // Medium priority: tabs that are currently loaded (not discarded)
-  if (tab.discarded !== true) priority += 50
+  if (tab.discarded !== true) {
+    priority += PRIORITY_WEIGHTS.LOADED_TAB
+  }
 
   // Lower priority: pinned tabs (they're likely to stay open)
-  if (tab.pinned) priority += 25
+  if (tab.pinned) {
+    priority += PRIORITY_WEIGHTS.PINNED_TAB
+  }
 
   return priority
 }
 
-// Smart reload: only reload tabs that need it, prioritizing active/recent tabs
-const smartReloadTabs = async (): Promise<void> => {
-  try {
-    // Query all HTTP/HTTPS tabs
-    const tabs = await chrome.tabs.query({ url: ['http://*/*', 'https://*/*'] })
+// Query all tabs that can have content scripts
+const queryReloadableTabs = (): Effect.Effect<chrome.tabs.Tab[], never, never> =>
+  Effect.tryPromise({
+    try: () => chrome.tabs.query({ url: [...TAB_URL_PATTERNS] }),
+    catch: () => [] as chrome.tabs.Tab[]
+  }).pipe(
+    Effect.catchAll(() => Effect.succeed([] as chrome.tabs.Tab[]))
+  )
 
-    // Filter out restricted URLs and check which tabs need reloading
-    const tabsToCheck: TabWithPriority[] = []
+// Check if a tab should be considered for reloading
+const isValidTab = (tab: chrome.tabs.Tab): boolean =>
+  typeof tab.id === 'number' && !isRestrictedUrl(tab.url)
 
-    for (const tab of tabs) {
-      if (typeof tab.id !== 'number' || isRestrictedUrl(tab.url)) {
-        continue
-      }
+// Create tab with priority information
+const createTabWithPriority = (tab: chrome.tabs.Tab): Effect.Effect<TabWithPriority, never, never> =>
+  Effect.gen(function* () {
+    const priority = getTabPriority(tab)
+    const isLoaded = yield* checkContentScriptLoaded(tab.id!)
 
-      const priority = getTabPriority(tab)
-      const isLoaded = await checkContentScriptLoaded(tab.id)
-
-      tabsToCheck.push({
-        tab,
-        priority,
-        needsReload: !isLoaded
-      })
+    return {
+      tab,
+      priority,
+      needsReload: !isLoaded
     }
+  })
+
+// Reload a single tab with logging
+const reloadTab = (tabId: number, priority: number, url?: string): Effect.Effect<void, never, never> =>
+  Effect.sync(() => {
+    console.log(`[Smart Reload] Reloading tab ${tabId} (priority: ${priority}): ${url || 'unknown'}`)
+    chrome.tabs.reload(tabId)
+  })
+
+// Smart reload: only reload tabs that need it, prioritizing active/recent tabs
+const smartReloadTabs = (): Effect.Effect<void, never, never> =>
+  Effect.gen(function* () {
+    // Query all HTTP/HTTPS tabs
+    const tabs = yield* queryReloadableTabs()
+
+    // Filter valid tabs and check which need reloading
+    const validTabs = Array.filter(tabs, isValidTab)
+    const tabsToCheck = yield* Effect.all(
+      Array.map(validTabs, createTabWithPriority),
+      { concurrency: 'unbounded' }
+    )
 
     // Filter to only tabs that need reloading and sort by priority (highest first)
-    const tabsToReload = tabsToCheck
-      .filter(t => t.needsReload)
+    const tabsToReload = Array.filter(tabsToCheck, (t) => t.needsReload)
       .sort((a, b) => b.priority - a.priority)
 
     // Reload tabs in priority order
-    for (const { tab, priority } of tabsToReload) {
-      if (typeof tab.id === 'number') {
-        console.log(`[Smart Reload] Reloading tab ${tab.id} (priority: ${priority}): ${tab.url}`)
-        chrome.tabs.reload(tab.id)
-      }
-    }
+    yield* Effect.all(
+      Array.map(tabsToReload, ({ tab, priority }) =>
+        reloadTab(tab.id!, priority, tab.url)
+      ),
+      { concurrency: 'unbounded' }
+    )
 
+    // Log results
     if (tabsToReload.length === 0) {
       console.log('[Smart Reload] No tabs needed reloading - all content scripts already loaded!')
     } else {
       console.log(`[Smart Reload] Reloaded ${tabsToReload.length} of ${tabs.length} tabs`)
     }
-  } catch (error) {
-    console.error('[Smart Reload] Error during smart reload:', error)
-  }
-}
+  }).pipe(
+    Effect.catchAll((error) =>
+      Effect.sync(() => {
+        console.error('[Smart Reload] Error during smart reload:', error)
+      })
+    )
+  )
 
 const setupPostInstallReload = (): Effect.Effect<void, never, never> =>
   Effect.sync(() => {
@@ -143,8 +211,8 @@ const setupPostInstallReload = (): Effect.Effect<void, never, never> =>
 
         console.log(`[Smart Reload] Extension ${details.reason} detected, performing smart reload...`)
 
-        // Use smart reload instead of reloading all tabs
-        smartReloadTabs()
+        // Use smart reload with Effect runtime
+        Effect.runFork(smartReloadTabs())
       }
     })
   })

--- a/src/background.ts
+++ b/src/background.ts
@@ -143,11 +143,7 @@ const createTabWithPriority = (tab: chrome.tabs.Tab) =>
 // Reload a single tab with logging
 const reloadTab = (tabId: number, priority: number, url?: string) =>
   Effect.sync(() => chrome.tabs.reload(tabId)).pipe(
-    Effect.tap(() =>
-      Effect.sync(() =>
-        console.log(`[Smart Reload] Reloading tab ${tabId} (priority: ${priority}): ${url || 'unknown'}`)
-      )
-    )
+    Effect.tap(() => Effect.log(`[Smart Reload] Reloading tab ${tabId} (priority: ${priority}): ${url || 'unknown'}`))
   )
 
 // Smart reload: only reload tabs that need it, prioritizing active/recent tabs
@@ -178,17 +174,11 @@ const smartReloadTabs = () =>
     return { tabsToReload: tabsToReload.length, totalTabs: tabs.length }
   }).pipe(
     Effect.tap(({ tabsToReload, totalTabs }) =>
-      Effect.sync(() =>
-        tabsToReload === 0
-          ? console.log('[Smart Reload] No tabs needed reloading - all content scripts already loaded!')
-          : console.log(`[Smart Reload] Reloaded ${tabsToReload} of ${totalTabs} tabs`)
-      )
+      tabsToReload === 0
+        ? Effect.log('[Smart Reload] No tabs needed reloading - all content scripts already loaded!')
+        : Effect.log(`[Smart Reload] Reloaded ${tabsToReload} of ${totalTabs} tabs`)
     ),
-    Effect.tapError((error) =>
-      Effect.sync(() =>
-        console.error('[Smart Reload] Error during smart reload:', error)
-      )
-    ),
+    Effect.tapError((error) => Effect.logError('[Smart Reload] Error during smart reload:', error)),
     Effect.catchAll(() => Effect.succeed(void 0))
   )
 
@@ -208,11 +198,7 @@ const setupPostInstallReload = () =>
         // Use smart reload with Effect runtime and logging
         Effect.runFork(
           Effect.succeed(details.reason).pipe(
-            Effect.tap((reason) =>
-              Effect.sync(() =>
-                console.log(`[Smart Reload] Extension ${reason} detected, performing smart reload...`)
-              )
-            ),
+            Effect.tap((reason) => Effect.log(`[Smart Reload] Extension ${reason} detected, performing smart reload...`)),
             Effect.flatMap(() => smartReloadTabs())
           )
         )

--- a/src/background.ts
+++ b/src/background.ts
@@ -72,8 +72,8 @@ const getTabPriority = (tab: chrome.tabs.Tab): number => {
     else if (hoursSinceAccess < 24) priority += 100 // Last 24 hours
   }
 
-  // Medium priority: visible (not hidden) tabs
-  if (!tab.hidden) priority += 50
+  // Medium priority: tabs that are currently loaded (not discarded)
+  if (tab.discarded !== true) priority += 50
 
   // Lower priority: pinned tabs (they're likely to stay open)
   if (tab.pinned) priority += 25

--- a/src/content.ts
+++ b/src/content.ts
@@ -59,6 +59,15 @@ const processMouseMovements = (): Effect.Effect<void, ChromeRuntimeError, never>
     )
   })
 
+// Health check listener - responds to ping messages from background script
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message.type === 'ping') {
+    sendResponse({ status: 'ok', loaded: true })
+    return true // Keep channel open for async response
+  }
+  return false
+})
+
 // Auto-start when script loads
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => Effect.runFork(processMouseMovements()))

--- a/src/content.ts
+++ b/src/content.ts
@@ -12,7 +12,7 @@ const HEALTH_CHECK_MESSAGE_TYPE = 'ping' as const
 const HEALTH_CHECK_RESPONSE = { status: 'ok', loaded: true } as const
 
 // Direct Chrome messaging function with offline handling
-const sendMessage = <T = any>(message: ChromeMessage): Effect.Effect<T, ChromeRuntimeError> =>
+const sendMessage = <T = any>(message: ChromeMessage) =>
   Effect.tryPromise({
     try: () => new Promise<T>((resolve, reject) => {
       try {
@@ -36,7 +36,7 @@ const sendMessage = <T = any>(message: ChromeMessage): Effect.Effect<T, ChromeRu
   })
 
 // Process mouse movements and send to background
-const processMouseMovements = (): Effect.Effect<void, ChromeRuntimeError, never> =>
+const processMouseMovements = () =>
   Effect.gen(function* () {
     const mouseStream = MouseTrackingServiceLive.createStream()
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -57,11 +57,7 @@ const processMouseMovements = () =>
         }
 
         yield* sendMessage(distanceMessage).pipe(
-          Effect.tapError((error) =>
-            Effect.sync(() =>
-              console.debug('Message send failed (extension still functional):', error)
-            )
-          ),
+          Effect.tapError((error) => Effect.logDebug('Message send failed (extension still functional):', error)),
           Effect.catchAll(() => Effect.succeed(void 0))
         )
       })

--- a/src/content.ts
+++ b/src/content.ts
@@ -57,11 +57,12 @@ const processMouseMovements = () =>
         }
 
         yield* sendMessage(distanceMessage).pipe(
-          Effect.catchAll((error) => {
-            // Log error but don't stop the stream - extension should continue tracking
-            console.debug('Message send failed (extension still functional):', error)
-            return Effect.succeed(void 0)
-          })
+          Effect.tapError((error) =>
+            Effect.sync(() =>
+              console.debug('Message send failed (extension still functional):', error)
+            )
+          ),
+          Effect.catchAll(() => Effect.succeed(void 0))
         )
       })
     )

--- a/src/services/badge-service.ts
+++ b/src/services/badge-service.ts
@@ -34,11 +34,7 @@ const setBadgeText = (text: string): Effect.Effect<void, BadgeError> =>
         cause: error,
       }),
   }).pipe(
-    Effect.tap(() =>
-      Effect.sync(() =>
-        console.log('🏷️ Badge: Set to:', text)
-      )
-    )
+    Effect.tap(() => Effect.log(`🏷️ Badge: Set to: ${text}`))
   )
 
 const getDisplayUnits = (

--- a/src/services/badge-service.ts
+++ b/src/services/badge-service.ts
@@ -23,7 +23,6 @@ const setBadgeText = (text: string): Effect.Effect<void, BadgeError> =>
     try: () => {
       if (chrome?.action?.setBadgeText) {
         chrome.action.setBadgeText({ text })
-        console.log('🏷️ Badge: Set to:', text)
       } else {
         throw new Error('chrome.action.setBadgeText not available')
       }
@@ -34,7 +33,13 @@ const setBadgeText = (text: string): Effect.Effect<void, BadgeError> =>
         value: text,
         cause: error,
       }),
-  })
+  }).pipe(
+    Effect.tap(() =>
+      Effect.sync(() =>
+        console.log('🏷️ Badge: Set to:', text)
+      )
+    )
+  )
 
 const getDisplayUnits = (
   total: number


### PR DESCRIPTION
Implements intelligent tab reloading that only reloads tabs where content scripts are not properly loaded, prioritizing active and recently accessed tabs.

Changes:
- Add health check ping/pong mechanism to content script
- Detect if content scripts are already loaded before reloading
- Prioritize tabs by activity: active > recent (1hr) > recent (24hr) > visible > pinned
- Handle both INSTALL and UPDATE events (not just install)
- Add detailed logging for debugging reload behavior

This solves the issue where old tabs don't work properly after extension installation, while avoiding unnecessary reloads of tabs that are already functioning correctly.